### PR TITLE
Amend external URL link under Renewal page

### DIFF
--- a/_regulated-dealers/3-renewal.md
+++ b/_regulated-dealers/3-renewal.md
@@ -92,7 +92,7 @@ The Registrar of Regulated Dealers may impose additional conditions or waive exi
 #### <a id="Fees and Period of Registration"></a> Fees, Registering your place(s) of business and Period of Registration
 <b>Fees and registering your place(s) of business</b><br>
 Regulated dealers must pay an application fee of S$140 for each renewal application to register with the Registrar. All payment must be made through [GoBusiness Licensing Portal](https://www.gobusiness.gov.sg/licences){:target="_blank"} using the following e-payment methods: PayPal, VISA, MasterCard, American Express or Discover.<br><br>
-If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.
+If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.
 <table>
   <tr>
     <th></th>


### PR DESCRIPTION
Under Renewal page, under 'Fees Registering your place(s) of business and Period of Registration' section (row 95), amend external link for '...place of business' to be directed/linked to 'Registration of Temporary Outlets' page

from: "...must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register."
to: "must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register"