### PR TITLE
edits to maroon 'Registering your place(s) of business and Fee calculation' header 

### DIFF
--- a/_regulated-dealers/1-registration.md
+++ b/_regulated-dealers/1-registration.md
@@ -6,7 +6,7 @@ breadcrumb: Registration
 collection_name: regulated-dealers
 ---
 
-<a href="#Registration">Registration </a> | <a href="#Who is Required to Register?">Who is Required to Register? </a> |<a href="#Registration Application Process">Registration Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees, Registering your place(s) of business and Period of Registration">Fees, Registering your place(s) of business and Period of Registration </a> | <a href="#I Need Help with Registration">I Need Help with Registration </a>
+<a href="#Registration">Registration </a> | <a href="#Who is Required to Register?">Who is Required to Register? </a> |<a href="#Registration Application Process">Registration Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees, Registering your Place(s) of Business and Period of Registration">Fees, Registering your Place(s) of Business and Period of Registration </a> | <a href="#I Need Help with Registration">I Need Help with Registration </a>
 
 #### <a id="Registration"></a> Registration
 

--- a/_regulated-dealers/1-registration.md
+++ b/_regulated-dealers/1-registration.md
@@ -96,7 +96,7 @@ You may submit your application via the [GoBusiness Licensing Portal](https://ww
   </tr>
 </table>
 
-#### <a id="Fees and Period of Registration"></a> Fees, Registering your place(s) of business and Period of Registration
+#### <a id="Fees and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
 <b>Fees and registering your place(s) of business</b><br>
 Regulated dealers must pay an application fee of S$140 for each application to register with the Registrar. All payment must be made through [GoBusiness Licensing Portal](https://www.gobusiness.gov.sg/licences){:target="_blank"} using the following e-payment methods: PayPal, VISA, MasterCard, American Express or Discover.<br><br>
 If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.

--- a/_regulated-dealers/1-registration.md
+++ b/_regulated-dealers/1-registration.md
@@ -6,7 +6,7 @@ breadcrumb: Registration
 collection_name: regulated-dealers
 ---
 
-<a href="#Registration">Registration </a> | <a href="#Who is Required to Register?">Who is Required to Register? </a> |<a href="#Registration Application Process">Registration Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees and Period of Registration">Fees and Period of Registration </a> | <a href="#I Need Help with Registration">I Need Help with Registration </a>
+<a href="#Registration">Registration </a> | <a href="#Who is Required to Register?">Who is Required to Register? </a> |<a href="#Registration Application Process">Registration Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees, Registering your place(s) of business and Period of Registration">Fees, Registering your place(s) of business and Period of Registration </a> | <a href="#I Need Help with Registration">I Need Help with Registration </a>
 
 #### <a id="Registration"></a> Registration
 

--- a/_regulated-dealers/1-registration.md
+++ b/_regulated-dealers/1-registration.md
@@ -96,7 +96,7 @@ You may submit your application via the [GoBusiness Licensing Portal](https://ww
   </tr>
 </table>
 
-#### <a id="Fees and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
+#### <a id="Fees, Registering your Place(s) of Business and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
 <b>Fees and registering your place(s) of business</b><br>
 Regulated dealers must pay an application fee of S$140 for each application to register with the Registrar. All payment must be made through [GoBusiness Licensing Portal](https://www.gobusiness.gov.sg/licences){:target="_blank"} using the following e-payment methods: PayPal, VISA, MasterCard, American Express or Discover.<br><br>
 If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.

--- a/_regulated-dealers/2-registration of temporary outlets.md
+++ b/_regulated-dealers/2-registration of temporary outlets.md
@@ -6,7 +6,7 @@ breadcrumb: Registration of Temporary Outlets
 collection_name: regulated-dealers
 ---
 
-#### <a id="Registration"></a> Registering your Place(s) of Business and Fee calculation
+#### <a id="Registration of Temporary Outlets"></a> Registering your Place(s) of Business and Fee calculation
 
 As part of the application to become a registered dealer, the dealer must register with the Registrar of Regulated Dealers (“**Registrar**”) the fixed place of business at which the dealer carries out a business of regulated dealing or a business as an intermediary for regulated dealing (“**regulated activity**”). If the dealer has no fixed place of business, the dealer must register either of the following places:
 

--- a/_regulated-dealers/2-registration of temporary outlets.md
+++ b/_regulated-dealers/2-registration of temporary outlets.md
@@ -6,7 +6,7 @@ breadcrumb: Registration of Temporary Outlets
 collection_name: regulated-dealers
 ---
 
-#### <a id="Registration"></a> Registering your place(s) of business and Fee calculation
+#### <a id="Registration"></a> Registering your Place(s) of Business and Fee calculation
 
 As part of the application to become a registered dealer, the dealer must register with the Registrar of Regulated Dealers (“**Registrar**”) the fixed place of business at which the dealer carries out a business of regulated dealing or a business as an intermediary for regulated dealing (“**regulated activity**”). If the dealer has no fixed place of business, the dealer must register either of the following places:
 

--- a/_regulated-dealers/3-renewal.md
+++ b/_regulated-dealers/3-renewal.md
@@ -6,7 +6,7 @@ breadcrumb: Renewal
 collection_name: regulated-dealers
 ---
 
-<a href="#Renewal of Registration">Renewal of Registration</a> | <a href="#Renewal Application Process">Renewal Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees and Period of Registration">Fees and Period of Registration </a> | <a href="#I Need Help with Renewal">I Need Help with Renewal </a>
+<a href="#Renewal of Registration">Renewal of Registration</a> | <a href="#Renewal Application Process">Renewal Application Process </a> | <a href="#Information Needed">Information Needed</a> | <a href="#Fees, Registering your Place(s) of Business and Period of Registration">Fees, Registering your Place(s) of Business and Period of Registration </a> | <a href="#I Need Help with Renewal">I Need Help with Renewal </a>
 
 #### <a id="Renewal of Registration"></a> Renewal of Registration
 
@@ -89,7 +89,7 @@ The Registrar of Regulated Dealers may impose additional conditions or waive exi
   </tr>
 </table>
 
-#### <a id="Fees and Period of Registration"></a> Fees, Registering your place(s) of business and Period of Registration
+#### <a id="Fees and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
 <b>Fees and registering your place(s) of business</b><br>
 Regulated dealers must pay an application fee of S$140 for each renewal application to register with the Registrar. All payment must be made through [GoBusiness Licensing Portal](https://www.gobusiness.gov.sg/licences){:target="_blank"} using the following e-payment methods: PayPal, VISA, MasterCard, American Express or Discover.<br><br>
 If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.

--- a/_regulated-dealers/3-renewal.md
+++ b/_regulated-dealers/3-renewal.md
@@ -89,7 +89,7 @@ The Registrar of Regulated Dealers may impose additional conditions or waive exi
   </tr>
 </table>
 
-#### <a id="Fees and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
+#### <a id="Fees, Registering your Place(s) of Business and Period of Registration"></a> Fees, Registering your Place(s) of Business and Period of Registration
 <b>Fees and registering your place(s) of business</b><br>
 Regulated dealers must pay an application fee of S$140 for each renewal application to register with the Registrar. All payment must be made through [GoBusiness Licensing Portal](https://www.gobusiness.gov.sg/licences){:target="_blank"} using the following e-payment methods: PayPal, VISA, MasterCard, American Express or Discover.<br><br>
 If the Registrar provides in-principle approval for your application, regulated dealers must pay a registration fee of S$300 per [place of business](https://acd.mlaw.gov.sg/registration-of-temporary-outlets/){:target="_blank"} per year calculated based on the number of outlets you operate and the period for which you register.


### PR DESCRIPTION
Under 'Registration of Temporary Outlets' page, amend the maroon header 'Registering your place(s) of business and Fee calculation' to Cap the words "Place(s)" and "Business"

from 'Registering your place(s) of business and Fee calculation'
to 'Registering your Place(s) of Business and Fee calculation'