### PR TITLE
Amend semi-annual return's landing page

### DIFF
--- a/news/past-events/_posts/2021-04-12-online-training-on-submission-of-semi-annual-returns.md
+++ b/news/past-events/_posts/2021-04-12-online-training-on-submission-of-semi-annual-returns.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sign Up For Online Training On Submission Of Semi-Annual Returns'
 date: 2021-04-12T00:00:00.000Z
-permalink: /news/upcoming-events/sign-up-for-online-training-on-submission-of-semi-annual-returns/
+permalink: /news/past-events/sign-up-for-online-training-on-submission-of-semi-annual-returns/
 
 ---
 


### PR DESCRIPTION
Amend semi-annual return landing page from 'upcoming events' page to 'past events' page:

from:
/news/upcoming-events/sign-up-for-online-training-on-submission-of-semi-annual-returns/
to:
/news/past-events/sign-up-for-online-training-on-submission-of-semi-annual-returns/