### PR TITLE
Updates for Guidance Paper briefing pages

### DIFF
--- a/_regulation/1-guidance-papers.md
+++ b/_regulation/1-guidance-papers.md
@@ -6,7 +6,7 @@ breadcrumb: 'Guidance Papers'
 ---
 #### [Guidance Paper on Strengthening AML/CFT Controls in the Precious Stones and Precious Metals ("PSPM") Sector](/images/Guidance Paper_20210616.pdf){:target="_blank"}
 
-MinLaw conducted a series of inspections and compliance reviews of regulated dealers targeted at assessing their level of compliance with the Precious Stones and Precious Metals (Prevention of Money Laundering and Terrorism Financing) Act 2019 ("**PSPM Act**") and and Precious Stones and Precious Metals (Prevention of Money Laundering and Terrorism Financing) Regulations 2020 ("**PMLTF Regulations**").
+MinLaw conducted a series of inspections and compliance reviews of regulated dealers targeted at assessing their level of compliance with the Precious Stones and Precious Metals (Prevention of Money Laundering and Terrorism Financing) Act 2019 ("**PSPM Act**") and Precious Stones and Precious Metals (Prevention of Money Laundering and Terrorism Financing) Regulations 2020 ("**PMLTF Regulations**").
  
 The [Guidance Paper](/images/Guidance Paper_20210616.pdf){:target="_blank"} sets out the key findings and MinLaw’s supervisory expectations of effective Anti-Money Laundering/Countering the Financing of Terrorism ("**AML/CFT**") controls in the precious stones and precious metals dealer ("**PSMD**") Sector. 
 

--- a/news/notices-from-the-registrar/_posts/2021-06-16-guidance-paper-issued-on-16-jun-2021.md
+++ b/news/notices-from-the-registrar/_posts/2021-06-16-guidance-paper-issued-on-16-jun-2021.md
@@ -40,3 +40,5 @@ MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to ta
 - Regulated dealers should evaluate the effectiveness of their AML/CFT measures against the findings and good practices highlighted in this Guidance Paper and take appropriate steps to address any gaps.
 
 - Regulated dealers may wish to attend MinLaw’s briefings on 7 July and 12 July 2021. Interested dealers may sign up for the briefings [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"}.
+
+[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]

--- a/news/past-events/_posts/2019-11-28-Onboarding-Workshops-for-Compliance-Officer.md
+++ b/news/past-events/_posts/2019-11-28-Onboarding-Workshops-for-Compliance-Officer.md
@@ -13,6 +13,6 @@ The OBW aims to enable the **compliance officer** of registered dealers to:
 (a) Perform an assessment of the money laundering ("**ML**") and terrorism financing ("**TF**") risks faced by their business; and <br>
 (b) Develop internal policies, procedures and controls ("**IPPC**") to manage and effectively mitigate the ML/TF risks.
 
-We would like to thank all participants for their support of this event. Please stay tuned to our website for any upcoming events organised by us.
+We would like to thank all participants for their support of this event from September 2019 to June 2020. Please stay tuned to our website for any upcoming events organised by us.
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2020-01-21-Induction-Briefings.md
+++ b/news/past-events/_posts/2020-01-21-Induction-Briefings.md
@@ -9,4 +9,6 @@ The Anti-Money Laundering/Countering the Financing of Terrorism Division ("**ACD
 
 The aim of the briefing was to provide an overview of the Precious Stones and Precious Metals (Prevention of Money Laundering and Terrorism Financing) Act 2019 ("**PSPM Act**"). Registered dealers may refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime.
 
+We would like to thank all participants for their support of this event from September 2019 to December 2019.
+
 You may download the presentation slides [here](/images/IB_Slides_English_20200629.pdf){:target="_blank"} (English) and [here](/images/IB_Slides_Chinese_20200629.pdf){:target="_blank"} (Mandarin). Please refer to the [Guidance Materials section](/guidance-materials/){:target="_blank"} for guidances.

--- a/news/past-events/_posts/2021-04-12-online-training-on-submission-of-semi-annual-returns.md
+++ b/news/past-events/_posts/2021-04-12-online-training-on-submission-of-semi-annual-returns.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sign Up For Online Training On Submission Of Semi-Annual Returns'
 date: 2021-04-12T00:00:00.000Z
-permalink: /news/past-events/sign-up-for-online-training-on-submission-of-semi-annual-returns/
+permalink: /news/past-events/online-training-on-submission-of-semi-annual-returns/
 
 ---
 

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -27,6 +27,6 @@ Each key area for improvement comprises the following elements:
 
 4. Key learning points – To highlight MinLaw’s supervisory expectations.
 
-MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
+We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -29,6 +29,6 @@ Each key area for improvement comprises the following elements:
 
 MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
 
-[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]
-
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.
+
+[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -27,6 +27,7 @@ Each key area for improvement comprises the following elements:
 
 4. Key learning points – To highlight MinLaw’s supervisory expectations.
 
-We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
+MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
+[Update in July 2021: <i>We would like to thank all participants for their support of this event in July 2021.</i> The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -28,6 +28,7 @@ Each key area for improvement comprises the following elements:
 4. Key learning points – To highlight MinLaw’s supervisory expectations.
 
 MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
+
 [<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Sign Up For Online Briefing On Guidance Paper
+title: Online Briefing On Guidance Paper
 date: 2021-06-16
-permalink: /news/past-events/sign-up-for-online-briefing-on-guidance-paper/
+permalink: /news/past-events/online-briefing-on-guidance-paper/
 ---
 
 The Anti-Money Laundering/Countering the Financing of Terrorism Division (“**ACD**”) of Ministry of Law is organising online briefings in July 2021 for registered precious stones and precious metals dealer (“**PSMD**”) to take regulated dealers through the [Guidance Paper](/images/Guidance Paper_20210616.pdf){:target="_blank"}. 

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -28,7 +28,6 @@ Each key area for improvement comprises the following elements:
 4. Key learning points – To highlight MinLaw’s supervisory expectations.
 
 MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
-
-[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
+[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -28,6 +28,7 @@ Each key area for improvement comprises the following elements:
 4. Key learning points – To highlight MinLaw’s supervisory expectations.
 
 MinLaw will be conducting online briefings on 7 July 2021 and 12 July 2021 to take regulated dealers through the Guidance Paper. The briefings will only be available in English. Each dealer may only send 1 representative to attend. Please click [here](https://go.gov.sg/pspm-guidance-paper-2021){:target="_blank"} to sign up for the online briefing.
-[Update in July 2021: <i>We would like to thank all participants for their support of this event in July 2021.</i> The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
+
+[<i>Update in July 2021</i>: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!
 
 Please refer to the ["**FAQs**"](https://va.ecitizen.gov.sg/cfp/customerPages/mlaw/explorefaq.aspx){:target="_blank"} under the Precious Stones and Precious Metals Dealers section for Frequently Asked Questions relating to the regulatory regime. For further queries, please click [here](https://eservices.mlaw.gov.sg/enquiry/){:target="_blank"}.

--- a/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
+++ b/news/past-events/_posts/2021-06-16-online-briefing-on-guidance-paper.md
@@ -2,7 +2,7 @@
 layout: post
 title: Sign Up For Online Briefing On Guidance Paper
 date: 2021-06-16
-permalink: /news/ongoing-events/sign-up-for-online-briefing-on-guidance-paper/
+permalink: /news/past-events/sign-up-for-online-briefing-on-guidance-paper/
 ---
 
 The Anti-Money Laundering/Countering the Financing of Terrorism Division (“**ACD**”) of Ministry of Law is organising online briefings in July 2021 for registered precious stones and precious metals dealer (“**PSMD**”) to take regulated dealers through the [Guidance Paper](/images/Guidance Paper_20210616.pdf){:target="_blank"}. 


### PR DESCRIPTION
Pull request for 16 Jul 2021:

1) Remove additional typo word "and" under "Guidance Papers" page

2) Added liner under IB page to indicat the month/year for the events to give context and also to record of when the events took place

3) Added liner under OBW page to indicat the month/year for the events to give context and also to record of when the events took place

4) Shifted 'Sign Up For Online Briefing On Guidance Paper' from "Ongoing Events" to "Past Events"

5) Added thank you closing liner after Guidance Paper briefing event is over:
"[Update on July 2021: We would like to thank all participants for their support of this event in July 2021. The presentation slides and video recording of the briefing will be shared with registered dealers and available on our website soon. Please stay tuned!]"

6) Amend Semi-Annual Return and Guidance Paper title and permalink, to remove “Sign Up For” (i.e, “Online Briefing on Guidance Paper” and “Online Training on Submission of Semi-Annual Returns”)