### PR TITLE
Updated button under resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ sections:
     - resources:
           title: 'Latest News'
           subtitle: 'News for Regulated Dealers'
-          button: 'More Information'
+          button: 'More Information on ACD news'
           url: /news/
 
 ---


### PR DESCRIPTION
From "More information" to "More information on ACD news" - as advised by ITD